### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/github-repo-configs/security/code-scanning/4](https://github.com/legnoh/github-repo-configs/security/code-scanning/4)

To generally fix this problem, an explicit `permissions` block should be set either at the workflow level or at the job (`ci`) level. The block should indicate the minimal set of permissions the workflow needs, following the principle of least privilege. The standard minimal default is:

```yaml
permissions:
  contents: read
```

If specific jobs require additional permissions, they should have their own, more permissive `permissions` blocks. In this case, reviewing the workflow shows that downloading artifacts, operating with the repository contents, and using tokens for custom operations are all done through GitHub Apps or through action inputs, not by assuming broad token permissions. Therefore, `contents: read` is the proper minimal permission at the workflow level for this job. To apply this, insert the `permissions:` block after the workflow `name:` and before `on:`.

**File/region/lines to change:**  
Edit `.github/workflows/ci.yml` to add:

```yaml
permissions:
  contents: read
```

…immediately after the `name: CI` line, i.e., after line 1.

No further imports, method definitions, or variable changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
